### PR TITLE
Update index.html for Safari full-screen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <link rel="icon" href="favicon.png">
     <link rel="apple-touch-icon" href="favicon.png"/>
     <title>HOOBS</title>


### PR DESCRIPTION
Adds support to display the HOOBS webpage in full-screen for Safari on iOS devices. Is included in config-ui-x by default.

(Not sure which one my first commit in `hoobs-org/gui` applied to, feel free to close this one but it is intended for the hoobs.local gui)